### PR TITLE
Add TypeInfo to manage types and their conversions

### DIFF
--- a/pb_plugins/dcsdkgen/methods.py
+++ b/pb_plugins/dcsdkgen/methods.py
@@ -1,21 +1,16 @@
 # -*- coding: utf-8 -*-
 from .utils import (remove_subscribe,
-                    extract_string_type,
-                    is_primitive_type,
                     filter_out_result,
                     no_return,
                     is_stream)
 from .name_parser import NameParser
+from .type_info import TypeInfo
 
 
 class Param:
 
-    def __init__(
-            self,
-            name,
-            type,
-            is_primitive):
-        self.name, self.type, self.is_primitive = name, type, is_primitive
+    def __init__(self, name, type_info):
+        self.name, self.type_info
 
 
 class Method(object):
@@ -47,8 +42,7 @@ class Method(object):
             self._params.append(
                 Param(
                     name=NameParser(field.name),
-                    type=extract_string_type(field),
-                    is_primitive=is_primitive_type(field))
+                    type_info=TypeInfo(field))
             )
 
     def extract_return_type_and_name(self, pb_method, responses):
@@ -63,10 +57,7 @@ class Method(object):
                 f"(and an optional '*Result')!\nError in {method_output}")
 
         if len(return_params) == 1:
-            self._return_type = \
-                extract_string_type(return_params[0])
-            self._is_return_type_primitive = \
-                is_primitive_type(return_params[0])
+            self._return_type = TypeInfo(return_params[0])
             self._return_name = NameParser(return_params[0].json_name)
 
     @property
@@ -186,7 +177,6 @@ class Request(Method):
             params=self._params,
             return_type=self._return_type,
             return_name=self._return_name,
-            is_return_type_primitive=self._is_return_type_primitive,
             plugin_name=self._plugin_name,
             request_rpc_type=self._request_rpc_type,
             package=self._package)
@@ -214,6 +204,5 @@ class Stream(Method):
             params=self._params,
             return_type=self._return_type,
             return_name=self._return_name,
-            is_return_type_primitive=self._is_return_type_primitive,
             plugin_name=self._plugin_name,
             package=self._package)

--- a/pb_plugins/dcsdkgen/struct.py
+++ b/pb_plugins/dcsdkgen/struct.py
@@ -1,11 +1,11 @@
 # -*- coding: utf-8 -*-
 
 
-from .utils import (extract_string_type,
-                    is_request,
+from .utils import (is_request,
                     is_response,
                     is_struct)
 from .name_parser import NameParser
+from .type_info import TypeInfo
 from jinja2.exceptions import TemplateNotFound
 
 
@@ -23,7 +23,7 @@ class Struct(object):
             self._fields.append(
                 (NameParser(
                     field.json_name),
-                    extract_string_type(field)))
+                    TypeInfo(field)))
 
     def __repr__(self):
         return self._template.render(plugin_name=self._plugin_name,

--- a/pb_plugins/dcsdkgen/type_info.py
+++ b/pb_plugins/dcsdkgen/type_info.py
@@ -1,0 +1,50 @@
+import json
+from os import environ
+
+
+class TypeInfo:
+    _default_types = {
+        1: "double",
+        2: "float",
+        4: "uint64_t",
+        5: "int",
+        8: "bool",
+        9: "std::string",
+        13: "uint32_t"
+    }
+
+    try:
+        _conversion_dict_path = environ.get(
+            "TEMPLATE_PATH", "./") + "/type_conversions"
+        with open(_conversion_dict_path, "r") as handle:
+            _conversion_dict = json.loads(handle.read())
+    except FileNotFoundError:
+        _conversion_dict = {}
+
+    def __init__(self, field):
+        self._field = field
+
+    @property
+    def name(self):
+        """ Extracts the string types """
+        type_id = self._field.type
+
+        if not self.is_primitive:
+            return str(self._field.type_name.split(".")[-1])
+        elif type_id not in self._default_types:
+            raise ValueError("UNKNOWN_TYPE")
+        elif self._default_types[self._type_id] in self._conversion_dict:
+            return self._conversion_dict[self._default_types[type_id]]
+        else:
+            return self._default_types[type_id]
+
+    @property
+    def is_result(self):
+        """ Check if the field is a *Result """
+        return self.name.endswith("Result")
+
+    @property
+    def is_primitive(self):
+        """ Check if the field type is primitive (e.g. bool,
+        float) or not (e.g message, enum) """
+        return self._field.type not in {11, 14}

--- a/pb_plugins/dcsdkgen/utils.py
+++ b/pb_plugins/dcsdkgen/utils.py
@@ -8,7 +8,7 @@ def no_return(method, responses):
     method_response = responses[method_output]
 
     if (1 == len(method_response.field) and
-            method_response.field[0].type_name.endswith("Result")):
+            TypeInfo(method_response.field[0]).is_result):
         return True
 
     if (0 == len(method_response.field)):
@@ -39,42 +39,11 @@ def is_struct(struct):
             not struct.name.endswith("Response"))
 
 
-def extract_string_type(field):
-    """ Extracts the string types """
-    types = {
-        1: "Double",
-        2: "Float",
-        4: "UInt64",
-        5: "Int",
-        8: "Bool",
-        9: "String",
-        13: "UInt32",
-        11: str(field.type_name.split(".")[-1]),
-        14: str(field.type_name.split(".")[-1])
-    }
-
-    if (field.type in types):
-        return types[field.type]
-    else:
-        return "UNKNOWN_TYPE"
-
-
-def is_primitive_type(field):
-    """ Check if the field type is primitive (e.g. bool,
-    float) or not (e.g message, enum) """
-    return (field.type not in {11, 14})
-
-
 def filter_out_result(fields):
     """ Filters out the result fields (".*Result$") """
     for field in fields:
-        if not is_result(field):
+        if not field.type_name.endswith("Result"):
             yield field
-
-
-def is_result(field):
-    """ Check if the field is a *Result """
-    return extract_string_type(field).endswith("Result")
 
 
 def remove_subscribe(name):


### PR DESCRIPTION
This is a proposition for #47. It looks for a file called `type_conversions` in the templates folder, and if existing, uses it for converting c++ types into whatever is defined in the file.

The file is expected to be a json object where keys are the c++ types and values are their conversions.

Fixes #47 