### PR TITLE
fix missing remove_subscribe function

### DIFF
--- a/pb_plugins/dcsdkgen/struct.py
+++ b/pb_plugins/dcsdkgen/struct.py
@@ -21,7 +21,7 @@ class Struct(object):
 
         for field in pb_struct.field:
             self._fields.append(
-                    (NameParser(field.json_name), TypeInfo(field)))
+                (NameParser(field.json_name), TypeInfo(field)))
 
     def __repr__(self):
         return self._template.render(plugin_name=self._plugin_name,

--- a/pb_plugins/dcsdkgen/utils.py
+++ b/pb_plugins/dcsdkgen/utils.py
@@ -46,6 +46,10 @@ def filter_out_result(fields):
             yield field
 
 
+def remove_subscribe(name):
+    return name.replace("Subscribe", "")
+
+
 def jinja_indent(_in_str, level):
     """ Indentation helper for the jinja2 templates """
 


### PR DESCRIPTION
I realized that this one is actually needed: `Subscribe*` comes from the proto file, and we need to remove the prefix before we pass the name to the templates.