### PR TITLE
A message name cannot be identical to the plugin name

### DIFF
--- a/protos/mission/mission.proto
+++ b/protos/mission/mission.proto
@@ -20,7 +20,7 @@ service MissionService {
 }
 
 message UploadMissionRequest {
-    Mission mission = 1;
+    MissionItems mission_items = 1;
 }
 message UploadMissionResponse {
     MissionResult mission_result = 1;
@@ -29,7 +29,7 @@ message UploadMissionResponse {
 message DownloadMissionRequest {}
 message DownloadMissionResponse {
     MissionResult mission_result = 1;
-    Mission mission = 2;
+    MissionItems mission_items = 2;
 }
 
 message StartMissionRequest {}
@@ -79,8 +79,8 @@ message SetReturnToLaunchAfterMissionRequest {
 }
 message SetReturnToLaunchAfterMissionResponse {}
 
-message Mission {
-    repeated MissionItem mission_item = 1;
+message MissionItems {
+    repeated MissionItem mission_items = 1;
 }
 
 message MissionItem {


### PR DESCRIPTION
Because depending of the language, a plugin becomes a class (`<Plugin>`), and a message becomes a class as well (`<Plugin>`), resulting in a conflict.