### PR TITLE
add support for repeated types in TypeInfo

### DIFF
--- a/pb_plugins/dcsdkgen/type_info.py
+++ b/pb_plugins/dcsdkgen/type_info.py
@@ -30,7 +30,8 @@ class TypeInfo:
         8: "bool",
         9: "std::string",
         12: "std::byte",
-        13: "uint32_t"
+        13: "uint32_t",
+        "repeated": {"prefix": "std::vector<", "suffix": ">"}
     }
 
     def __init__(self, field, conversion_dict):
@@ -40,6 +41,21 @@ class TypeInfo:
     @property
     def name(self):
         """ Extracts the string types """
+        inner_type = self._extract_inner_type()
+
+        if self.is_repeated:
+            if "repeated" in self._conversion_dict:
+                prefix = prefix = self._conversion_dict["repeated"]["prefix"]
+                suffix = self._conversion_dict["repeated"]["suffix"]
+            else:
+                prefix = self._default_types["repeated"]["prefix"]
+                suffix = self._default_types["repeated"]["suffix"]
+
+            return f"{prefix}{inner_type}{suffix}"
+        else:
+            return inner_type
+
+    def _extract_inner_type(self):
         type_id = self._field.type
 
         if not self.is_primitive:
@@ -61,3 +77,9 @@ class TypeInfo:
         """ Check if the field type is primitive (e.g. bool,
         float) or not (e.g message, enum) """
         return self._field.type not in {11, 14}
+
+    @property
+    def is_repeated(self):
+        """ Check if the field is a repeated type (in which
+        case it is converted to a list) """
+        return self._field.label == 3

--- a/pb_plugins/dcsdkgen/utils.py
+++ b/pb_plugins/dcsdkgen/utils.py
@@ -7,7 +7,6 @@ type_info_factory = TypeInfoFactory()
 
 
 class Param:
-
     def __init__(self, name, type_info):
         self.name = name
         self.type_info = type_info

--- a/pb_plugins/test/test_type_info.py
+++ b/pb_plugins/test/test_type_info.py
@@ -10,9 +10,13 @@ class TestTypeInfo(unittest.TestCase):
         "bool": "converted_bool"
     } """
 
+    _conversion_dict_data_repeatable = """ {
+        "repeated": { "prefix": "prefix[", "suffix": "]suffix" }
+    } """
+
     def setUp(self):
-        self.primitive_field = namedtuple("primitive_field", "type")
-        self.non_primitive_field = namedtuple("non_primitive_field", "type type_name")
+        self.primitive_field = namedtuple("primitive_field", "type label")
+        self.non_primitive_field = namedtuple("non_primitive_field", "type type_name label")
 
         self.bool_id = 8
         self.bool_expected_default_str = "bool"
@@ -23,42 +27,46 @@ class TestTypeInfo(unittest.TestCase):
 
         self.invalid_id = 42
 
+        self.non_repeated_label = 1
+        self.repeated_label = 3
+
     @patch("builtins.open", new_callable=mock_open)
     def test_name_uses_default_when_no_conversion_file(self, mock_file):
         mock_file.side_effect = FileNotFoundError()
         type_info_factory = TypeInfoFactory()
 
-        type_info = type_info_factory.create(self.primitive_field(self.bool_id))
+        type_info = type_info_factory.create(self.primitive_field(self.bool_id, self.non_repeated_label))
 
         self.assertEqual(type_info.name, self.bool_expected_default_str)
 
     @patch("builtins.open", new_callable=mock_open, read_data=_conversion_dict_data)
     def test_name_uses_default_when_no_conversion(self, mock_file):
         type_info_factory = TypeInfoFactory()
-        type_info = type_info_factory.create(self.primitive_field(self.double_id))
+        type_info = type_info_factory.create(self.primitive_field(self.double_id, self.non_repeated_label))
 
         self.assertEqual(type_info.name, self.double_expected_default_str)
 
     @patch("builtins.open", new_callable=mock_open, read_data=_conversion_dict_data)
     def test_name_converts_type_when_conversion(self, mock_file):
         type_info_factory = TypeInfoFactory()
-        type_info = type_info_factory.create(self.primitive_field(self.bool_id))
+        type_info = type_info_factory.create(self.primitive_field(self.bool_id, self.non_repeated_label))
 
         self.assertEqual(type_info.name, self.bool_expected_converted_str)
 
     @patch("builtins.open", new_callable=mock_open, read_data=_conversion_dict_data)
     def test_name_raises_error_when_invalid_type(self, mock_file):
         type_info_factory = TypeInfoFactory()
-        type_info = type_info_factory.create(self.primitive_field(self.invalid_id))
+        type_info = type_info_factory.create(self.primitive_field(self.invalid_id, self.non_repeated_label))
 
-        self.assertRaises(ValueError)
+        with self.assertRaises(ValueError):
+            type_info.name
 
     @patch("builtins.open", new_callable=mock_open, read_data=_conversion_dict_data)
     def test_primitive_false_for_complex_types(self, mock_file):
         type_info_factory = TypeInfoFactory()
 
         for type_id in {11, 14}:
-            non_primitive_type = type_info_factory.create(self.primitive_field(type_id))
+            non_primitive_type = type_info_factory.create(self.primitive_field(type_id, self.non_repeated_label))
             self.assertFalse(non_primitive_type.is_primitive)
 
     @patch("builtins.open", new_callable=mock_open, read_data=_conversion_dict_data)
@@ -66,7 +74,7 @@ class TestTypeInfo(unittest.TestCase):
         type_info_factory = TypeInfoFactory()
 
         for type_id in {1, 2, 3, 4, 5, 8, 9, 12, 13}:
-            primitive_type = type_info_factory.create(self.primitive_field(type_id))
+            primitive_type = type_info_factory.create(self.primitive_field(type_id, self.non_repeated_label))
             self.assertTrue(primitive_type.is_primitive)
 
     @patch("builtins.open", new_callable=mock_open, read_data=_conversion_dict_data)
@@ -74,7 +82,7 @@ class TestTypeInfo(unittest.TestCase):
         type_info_factory = TypeInfoFactory()
 
         for type_id in {1, 2, 3, 4, 5, 8, 9, 12, 13}:
-            primitive_type = type_info_factory.create(self.primitive_field(type_id))
+            primitive_type = type_info_factory.create(self.primitive_field(type_id, self.non_repeated_label))
             self.assertFalse(primitive_type.is_result)
 
     @patch("builtins.open", new_callable=mock_open, read_data=_conversion_dict_data)
@@ -82,7 +90,7 @@ class TestTypeInfo(unittest.TestCase):
         type_info_factory = TypeInfoFactory()
 
         for type_id in {11, 14}:
-            complex_type = type_info_factory.create(self.non_primitive_field(type_id, "SomeNonResultType"))
+            complex_type = type_info_factory.create(self.non_primitive_field(type_id, "SomeNonResultType", self.non_repeated_label))
             self.assertFalse(complex_type.is_result)
 
     @patch("builtins.open", new_callable=mock_open, read_data=_conversion_dict_data)
@@ -90,8 +98,64 @@ class TestTypeInfo(unittest.TestCase):
         type_info_factory = TypeInfoFactory()
 
         for type_id in {11, 14}:
-            complex_type = type_info_factory.create(self.non_primitive_field(type_id, "SomeResult"))
+            complex_type = type_info_factory.create(self.non_primitive_field(type_id, "SomeResult", self.non_repeated_label))
             self.assertTrue(complex_type.is_result)
+
+    @patch("builtins.open", new_callable=mock_open, read_data=_conversion_dict_data_repeatable)
+    def test_repeated_false_for_non_repeated_primitive(self, mock_file):
+        type_info_factory = TypeInfoFactory()
+        non_repeated_primitive_type = type_info_factory.create(self.primitive_field(self.double_id, self.non_repeated_label))
+
+        self.assertFalse(non_repeated_primitive_type.is_repeated)
+
+    @patch("builtins.open", new_callable=mock_open, read_data=_conversion_dict_data_repeatable)
+    def test_repeated_true_for_repeated_primitive(self, mock_file):
+        type_info_factory = TypeInfoFactory()
+        repeated_primitive_type = type_info_factory.create(self.primitive_field(self.double_id, self.repeated_label))
+
+        self.assertTrue(repeated_primitive_type.is_repeated)
+
+    @patch("builtins.open", new_callable=mock_open, read_data=_conversion_dict_data_repeatable)
+    def test_repeated_false_for_non_repeated(self, mock_file):
+        type_info_factory = TypeInfoFactory()
+        non_repeated_type = type_info_factory.create(self.non_primitive_field(11, "SomeNonResultType", self.non_repeated_label))
+
+        self.assertFalse(non_repeated_type.is_repeated)
+
+    @patch("builtins.open", new_callable=mock_open, read_data=_conversion_dict_data_repeatable)
+    def test_repeated_true_for_repeated(self, mock_file):
+        type_info_factory = TypeInfoFactory()
+        repeated_type = type_info_factory.create(self.non_primitive_field(11, "SomeNonResultType", self.repeated_label))
+
+        self.assertTrue(repeated_type.is_repeated)
+
+    @patch("builtins.open", new_callable=mock_open, read_data=_conversion_dict_data_repeatable)
+    def test_name_adds_prefix_suffix_for_repeated_primitive(self, mock_file):
+        type_info_factory = TypeInfoFactory()
+        type_info = type_info_factory.create(self.primitive_field(self.double_id, self.repeated_label))
+
+        self.assertEqual(type_info.name, "prefix[double]suffix")
+
+    @patch("builtins.open", new_callable=mock_open, read_data=_conversion_dict_data)
+    def test_name_adds_default_prefix_suffix_when_repeated_primitive_not_in_conversion_dict(self, mock_file):
+        type_info_factory = TypeInfoFactory()
+        type_info = type_info_factory.create(self.primitive_field(self.double_id, self.repeated_label))
+
+        self.assertEqual(type_info.name, "std::vector<double>")
+
+    @patch("builtins.open", new_callable=mock_open, read_data=_conversion_dict_data_repeatable)
+    def test_name_adds_prefix_suffix_for_repeated(self, mock_file):
+        type_info_factory = TypeInfoFactory()
+        type_info = type_info_factory.create(self.non_primitive_field(11, "SomeNonResultType", self.repeated_label))
+
+        self.assertEqual(type_info.name, "prefix[SomeNonResultType]suffix")
+
+    @patch("builtins.open", new_callable=mock_open, read_data=_conversion_dict_data)
+    def test_name_adds_default_prefix_suffix_when_repeated_not_in_conversion_dict(self, mock_file):
+        type_info_factory = TypeInfoFactory()
+        type_info = type_info_factory.create(self.non_primitive_field(11, "SomeNonResultType", self.repeated_label))
+
+        self.assertEqual(type_info.name, "std::vector<SomeNonResultType>")
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
The conversion dict file now can have a `repeated` entry that defines the `prefix` and `suffix` for a repeated type.

For instance, the default is:

    { "repeated", { "prefix": "std::vector<", "suffix": ">" } }

Meaning that a `repeated double` will become `std::vector<double>`.