### PR TITLE
Support nested structs

### DIFF
--- a/pb_plugins/dcsdkgen/autogen.py
+++ b/pb_plugins/dcsdkgen/autogen.py
@@ -20,7 +20,8 @@ class AutoGen(object):
         for proto_file in request.proto_file:
             plugin_name = proto_file.name.split('.')[0].capitalize()
 
-            enums = Enum.collect_enums(proto_file.package,
+            enums = Enum.collect_enums(plugin_name,
+                                       proto_file.package,
                                        proto_file.enum_type,
                                        template_env)
 

--- a/pb_plugins/dcsdkgen/enum.py
+++ b/pb_plugins/dcsdkgen/enum.py
@@ -5,12 +5,19 @@ from .name_parser import NameParser
 class Enum(object):
     """ Enum """
 
-    def __init__(self, plugin_name, package, template_env, pb_enum):
+    def __init__(
+            self,
+            plugin_name,
+            package,
+            template_env,
+            pb_enum,
+            parent_struct=None):
         self._plugin_name = NameParser(plugin_name)
         self._package = NameParser(package)
         self._template = template_env.get_template("enum.j2")
         self._name = NameParser(pb_enum.name)
         self._values = []
+        self._parent_struct = parent_struct
 
         for value in pb_enum.value:
             self._values.append(NameParser(value.name))
@@ -19,13 +26,20 @@ class Enum(object):
         return self._template.render(plugin_name=self._plugin_name,
                                      package=self._package,
                                      name=self._name,
-                                     values=self._values)
+                                     values=self._values,
+                                     parent_struct=self._parent_struct)
 
     @staticmethod
-    def collect_enums(plugin_name, package, enums, template_env):
+    def collect_enums(
+            plugin_name,
+            package,
+            enums,
+            template_env,
+            parent_struct=None):
         _enums = {}
 
         for enum in enums:
-            _enums[enum.name] = Enum(plugin_name, package, template_env, enum)
+            _enums[enum.name] = Enum(
+                plugin_name, package, template_env, enum, parent_struct)
 
         return _enums

--- a/pb_plugins/dcsdkgen/enum.py
+++ b/pb_plugins/dcsdkgen/enum.py
@@ -5,7 +5,8 @@ from .name_parser import NameParser
 class Enum(object):
     """ Enum """
 
-    def __init__(self, package, template_env, pb_enum):
+    def __init__(self, plugin_name, package, template_env, pb_enum):
+        self._plugin_name = NameParser(plugin_name)
         self._package = NameParser(package)
         self._template = template_env.get_template("enum.j2")
         self._name = NameParser(pb_enum.name)
@@ -15,15 +16,16 @@ class Enum(object):
             self._values.append(NameParser(value.name))
 
     def __repr__(self):
-        return self._template.render(name=self._name,
-                                     values=self._values,
-                                     package=self._package)
+        return self._template.render(plugin_name=self._plugin_name,
+                                     package=self._package,
+                                     name=self._name,
+                                     values=self._values)
 
     @staticmethod
-    def collect_enums(package, enums, template_env):
+    def collect_enums(plugin_name, package, enums, template_env):
         _enums = {}
 
         for enum in enums:
-            _enums[enum.name] = Enum(package, template_env, enum)
+            _enums[enum.name] = Enum(plugin_name, package, template_env, enum)
 
         return _enums

--- a/pb_plugins/dcsdkgen/struct.py
+++ b/pb_plugins/dcsdkgen/struct.py
@@ -20,8 +20,14 @@ class Struct(object):
         self._template = template_env.get_template("struct.j2")
         self._name = NameParser(pb_struct.name)
         self._fields = []
-        self._nested_enums = Enum.collect_enums(plugin_name, package, pb_struct.enum_type, template_env)
-        self._nested_structs = Struct.collect_structs(plugin_name, package, pb_struct.nested_type, template_env)
+        self._nested_enums = Enum.collect_enums(
+            plugin_name,
+            package,
+            pb_struct.enum_type,
+            template_env,
+            parent_struct=self._name)
+        self._nested_structs = Struct.collect_structs(
+            plugin_name, package, pb_struct.nested_type, template_env)
 
         for field in pb_struct.field:
             self._fields.append(

--- a/pb_plugins/dcsdkgen/struct.py
+++ b/pb_plugins/dcsdkgen/struct.py
@@ -1,12 +1,13 @@
 # -*- coding: utf-8 -*-
 
 
+from .enum import Enum
+from .name_parser import NameParser
 from .utils import (is_request,
                     is_response,
                     is_struct,
                     Param,
                     type_info_factory)
-from .name_parser import NameParser
 from jinja2.exceptions import TemplateNotFound
 
 
@@ -19,6 +20,8 @@ class Struct(object):
         self._template = template_env.get_template("struct.j2")
         self._name = NameParser(pb_struct.name)
         self._fields = []
+        self._nested_enums = Enum.collect_enums(plugin_name, package, pb_struct.enum_type, template_env)
+        self._nested_structs = Struct.collect_structs(plugin_name, package, pb_struct.nested_type, template_env)
 
         for field in pb_struct.field:
             self._fields.append(
@@ -29,7 +32,9 @@ class Struct(object):
         return self._template.render(plugin_name=self._plugin_name,
                                      package=self._package,
                                      name=self._name,
-                                     fields=self._fields)
+                                     fields=self._fields,
+                                     nested_enums=self._nested_enums,
+                                     nested_structs=self._nested_structs)
 
     @staticmethod
     def collect_structs(plugin_name, package, structs, template_env):

--- a/pb_plugins/dcsdkgen/type_info.py
+++ b/pb_plugins/dcsdkgen/type_info.py
@@ -41,7 +41,7 @@ class TypeInfo:
     @property
     def name(self):
         """ Extracts the string types """
-        inner_type = self._extract_inner_type()
+        inner_type = self.inner_name
 
         if self.is_repeated:
             if "repeated" in self._conversion_dict:
@@ -55,7 +55,11 @@ class TypeInfo:
         else:
             return inner_type
 
-    def _extract_inner_type(self):
+    @property
+    def inner_name(self):
+        """ Extracts inner type name. Only different for repeated types,
+        where e.g. type name "std::vector<int>" has "int"
+        as its inner_name """
         type_id = self._field.type
 
         if not self.is_primitive:

--- a/pb_plugins/test/test_type_info.py
+++ b/pb_plugins/test/test_type_info.py
@@ -157,5 +157,13 @@ class TestTypeInfo(unittest.TestCase):
 
         self.assertEqual(type_info.name, "std::vector<SomeNonResultType>")
 
+    @patch("builtins.open", new_callable=mock_open, read_data=_conversion_dict_data_repeatable)
+    def test_inner_name_for_repeated(self, mock_file):
+        type_info_factory = TypeInfoFactory()
+        type_info = type_info_factory.create(self.non_primitive_field(11, "SomeNonResultType", self.repeated_label))
+
+        self.assertEqual(type_info.inner_name, "SomeNonResultType")
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
* Add recursive support for nested structs: a struct can contain structs and enums now
* An enum must know in which struct it is defined, because its values are defined in the namespace of the parent (hence the need for this `parent_struct` in `Enum`)
* Need to expose the "inner name" of a repeated type. Say for `std::vector<int>`, templates sometimes need to access `int` only.

@xvzf: FYI. I'm merging because that's already a big improvement, but I'd be happy to have your review and improve that later.