### PR TITLE
pb_plugins: improve name_parser inputs handling

### DIFF
--- a/pb_plugins/dcsdkgen/name_parser.py
+++ b/pb_plugins/dcsdkgen/name_parser.py
@@ -4,15 +4,27 @@ import re
 class NameParser:
 
     def __init__(self, name):
-        self._name = name
+        """ Tries to detect the input format and save name as upper camel case.
+            This assumes that the input is either given as lower_snake_case,
+            upper_snake_case, UPPERCASE, UPPERCASE_SNAKE, UpperCamelCase or 
+            lowerCamelCase. Other inputs are undefined behavior.
+        """
+
+        if '_' in name: # Snake case
+            words = name.split('_')
+            self._name = ''.join(word.title() for word in words)
+        else:
+            if name[0].isupper():
+                if name.isupper(): # All uppercase
+                    self._name = name.title()
+                else: # Already UpperCamelCase
+                    self._name = name
+            else: # lowerCamelCase
+                self._name = name[0].upper() + name[1:]
 
     @property
     def uppercase(self):
-        return self._name.upper()
-
-    @property
-    def lowercase(self):
-        return self._name.lower()
+        return self.upper_snake_case.upper()
 
     @property
     def upper_camel_case(self):

--- a/pb_plugins/test/test_name_parser.py
+++ b/pb_plugins/test/test_name_parser.py
@@ -5,32 +5,143 @@ from dcsdkgen.name_parser import NameParser
 class TestNameParser(unittest.TestCase):
 
     def setUp(self):
-        self.arbitrary_str = "arBiTrarY_NaME"
-        self.simple_upper_camel_case_str = "SimpleString"
+        self.upper_camel_input = "FormattedName"
+        self.lower_camel_input = "formattedName"
+        self.upper_snake_input = "Formatted_Name"
+        self.lower_snake_input = "formatted_name"
+        self.only_upper_snake_input = "FORMATTED_NAME"
+        self.only_upper_input = "NAME"
 
-    def test_uppercase(self):
-        name = NameParser(self.arbitrary_str)
-        self.assertEqual('ARBITRARY_NAME', name.uppercase)
+        self.uppercase = "FORMATTED_NAME"
+        self.upper_camel_case = "FormattedName"
+        self.lower_camel_case = "formattedName"
+        self.upper_snake_case = "Formatted_Name"
+        self.lower_snake_case = "formatted_name"
 
-    def test_lowercase(self):
-        name = NameParser(self.arbitrary_str)
-        self.assertEqual('arbitrary_name', name.lowercase)
+        self.single_uppercase = "NAME"
+        self.single_upper_case = "Name"
+        self.single_lower_case = "name"
 
-    def test_simple_upper_camel_case(self):
-        name = NameParser(self.simple_upper_camel_case_str)
-        self.assertEqual(self.simple_upper_camel_case_str, name.upper_camel_case)
+    def test_upper_camel_to_uppercase(self):
+        name = NameParser(self.upper_camel_input)
+        self.assertEqual(self.uppercase, name.uppercase)
 
-    def test_simple_lower_camel_case(self):
-        name = NameParser(self.simple_upper_camel_case_str)
-        self.assertEqual('simpleString', name.lower_camel_case)
+    def test_lower_camel_to_uppercase(self):
+        name = NameParser(self.lower_camel_input)
+        self.assertEqual(self.uppercase, name.uppercase)
 
-    def test_simple_upper_snake_case(self):
-        name = NameParser(self.simple_upper_camel_case_str)
-        self.assertEqual('Simple_String', name.upper_snake_case)
+    def test_upper_snake_to_uppercase(self):
+        name = NameParser(self.upper_snake_input)
+        self.assertEqual(self.uppercase, name.uppercase)
 
-    def test_simple_lower_snake_case(self):
-        name = NameParser(self.simple_upper_camel_case_str)
-        self.assertEqual('simple_string', name.lower_snake_case)
+    def test_lower_snake_to_uppercase(self):
+        name = NameParser(self.lower_snake_input)
+        self.assertEqual(self.uppercase, name.uppercase)
+
+    def test_only_upper_to_uppercase(self):
+        name = NameParser(self.only_upper_input)
+        self.assertEqual(self.single_uppercase, name.uppercase)
+
+    def test_only_upper_snake_to_uppercase(self):
+        name = NameParser(self.only_upper_snake_input)
+        self.assertEqual(self.uppercase, name.uppercase)
+
+    def test_upper_camel_to_upper_camel_case(self):
+        name = NameParser(self.upper_camel_input)
+        self.assertEqual(self.upper_camel_case, name.upper_camel_case)
+
+    def test_lower_camel_to_upper_camel_case(self):
+        name = NameParser(self.lower_camel_input)
+        self.assertEqual(self.upper_camel_case, name.upper_camel_case)
+
+    def test_upper_snake_to_upper_camel_case(self):
+        name = NameParser(self.upper_snake_input)
+        self.assertEqual(self.upper_camel_case, name.upper_camel_case)
+
+    def test_lower_snake_to_upper_camel_case(self):
+        name = NameParser(self.lower_snake_input)
+        self.assertEqual(self.upper_camel_case, name.upper_camel_case)
+
+    def test_only_upper_to_upper_camel_case(self):
+        name = NameParser(self.only_upper_input)
+        self.assertEqual(self.single_upper_case, name.upper_camel_case)
+
+    def test_only_upper_snake_to_upper_camel_case(self):
+        name = NameParser(self.only_upper_snake_input)
+        self.assertEqual(self.upper_camel_case, name.upper_camel_case)
+
+    def test_upper_camel_to_lower_camel_case(self):
+        name = NameParser(self.upper_camel_input)
+        self.assertEqual(self.lower_camel_case, name.lower_camel_case)
+
+    def test_lower_camel_to_lower_camel_case(self):
+        name = NameParser(self.lower_camel_input)
+        self.assertEqual(self.lower_camel_case, name.lower_camel_case)
+
+    def test_upper_snake_to_lower_camel_case(self):
+        name = NameParser(self.upper_snake_input)
+        self.assertEqual(self.lower_camel_case, name.lower_camel_case)
+
+    def test_lower_snake_to_lower_camel_case(self):
+        name = NameParser(self.lower_snake_input)
+        self.assertEqual(self.lower_camel_case, name.lower_camel_case)
+
+    def test_only_upper_to_lower_camel_case(self):
+        name = NameParser(self.only_upper_input)
+        self.assertEqual(self.single_lower_case, name.lower_camel_case)
+
+    def test_only_upper_snake_to_lower_camel_case(self):
+        name = NameParser(self.only_upper_snake_input)
+        self.assertEqual(self.lower_camel_case, name.lower_camel_case)
+
+    def test_upper_camel_to_upper_snake_case(self):
+        name = NameParser(self.upper_camel_input)
+        self.assertEqual(self.upper_snake_case, name.upper_snake_case)
+
+    def test_lower_camel_to_upper_snake_case(self):
+        name = NameParser(self.lower_camel_input)
+        self.assertEqual(self.upper_snake_case, name.upper_snake_case)
+
+    def test_upper_snake_to_upper_snake_case(self):
+        name = NameParser(self.upper_snake_input)
+        self.assertEqual(self.upper_snake_case, name.upper_snake_case)
+
+    def test_lower_snake_to_upper_snake_case(self):
+        name = NameParser(self.lower_snake_input)
+        self.assertEqual(self.upper_snake_case, name.upper_snake_case)
+
+    def test_only_upper_to_upper_snake_case(self):
+        name = NameParser(self.only_upper_input)
+        self.assertEqual(self.single_upper_case, name.upper_snake_case)
+
+    def test_only_upper_snake_to_upper_snake_case(self):
+        name = NameParser(self.only_upper_snake_input)
+        self.assertEqual(self.upper_snake_case, name.upper_snake_case)
+
+    def test_upper_camel_to_lower_snake_case(self):
+        name = NameParser(self.upper_camel_input)
+        self.assertEqual(self.lower_snake_case, name.lower_snake_case)
+
+    def test_lower_camel_to_lower_snake_case(self):
+        name = NameParser(self.lower_camel_input)
+        self.assertEqual(self.lower_snake_case, name.lower_snake_case)
+
+    def test_upper_snake_to_lower_snake_case(self):
+        name = NameParser(self.upper_snake_input)
+        self.assertEqual(self.lower_snake_case, name.lower_snake_case)
+
+    def test_lower_snake_to_lower_snake_case(self):
+        name = NameParser(self.lower_snake_input)
+        self.assertEqual(self.lower_snake_case, name.lower_snake_case)
+
+    def test_only_upper_to_lower_snake_case(self):
+        name = NameParser(self.only_upper_input)
+        self.assertEqual(self.single_lower_case, name.lower_snake_case)
+
+    def test_only_upper_snake_to_lower_snake_case(self):
+        name = NameParser(self.only_upper_snake_input)
+        self.assertEqual(self.lower_snake_case, name.lower_snake_case)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
 It was assuming upper camel case before, but it actually happens that the input arrives as lower_snake_case.

Also, uppercase should keep underscores (e.g. `TakePhoto` should become `TAKE_PHOTO` and not `TAKEPHOTO`, which doesn't really make sense).

Finally, lowercase is apparently superfluous.