### PR TITLE
pb_plugins: add has_result to methods and file

### DIFF
--- a/pb_plugins/dcsdkgen/autogen.py
+++ b/pb_plugins/dcsdkgen/autogen.py
@@ -5,7 +5,7 @@ from .autogen_file import File
 from .methods import Method
 from .struct import Struct
 from .enum import Enum
-from .utils import get_template_env
+from .utils import (get_template_env, has_result)
 
 
 class AutoGen(object):
@@ -49,7 +49,8 @@ class AutoGen(object):
                             template_env,
                             enums,
                             structs,
-                            methods)
+                            methods,
+                            has_result(structs))
 
             _codegen_response = plugin_pb2.CodeGeneratorResponse()
 

--- a/pb_plugins/dcsdkgen/autogen_file.py
+++ b/pb_plugins/dcsdkgen/autogen_file.py
@@ -12,17 +12,20 @@ class File(object):
             template_env,
             enums,
             structs,
-            methods):
+            methods,
+            has_result):
         self._package = NameParser(package)
         self._plugin_name = NameParser(plugin_name)
         self._template = template_env.get_template("file.j2")
         self._enums = enums
         self._structs = structs
         self._methods = methods
+        self._has_result = has_result
 
     def __repr__(self):
         return self._template.render(package=self._package,
                                      plugin_name=self._plugin_name,
                                      enums=self._enums.values(),
                                      structs=self._structs.values(),
-                                     methods=self._methods.values())
+                                     methods=self._methods.values(),
+                                     has_result=self._has_result)

--- a/pb_plugins/dcsdkgen/utils.py
+++ b/pb_plugins/dcsdkgen/utils.py
@@ -43,7 +43,7 @@ def is_response(struct):
 
 
 def is_struct(struct):
-    """ Check if the message is a data structure or an rpc
+    """ Checks if the message is a data structure or an rpc
     request/response"""
     return (not struct.name.endswith("Request") and
             not struct.name.endswith("Response"))
@@ -54,6 +54,16 @@ def filter_out_result(fields):
     for field in fields:
         if not field.type_name.endswith("Result"):
             yield field
+
+
+def has_result(structs):
+    """ Checks if at least one struct is a *Result$. 
+        The expected input is a list of struct names. """
+    for struct in structs:
+        if struct.endswith("Result"):
+            return True
+
+    return False
 
 
 def remove_subscribe(name):


### PR DESCRIPTION
There is a need to know if a file or a method contains a result or not. In Python, for instance, a method may raise an error if the result is not SUCCESS. If there is no result, it means that the method cannot fail, in which case it should not do anything.