### PR TITLE
pb_plugins: add support for initialisms

### DIFF
--- a/pb_plugins/dcsdkgen/autogen_file.py
+++ b/pb_plugins/dcsdkgen/autogen_file.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from .name_parser import NameParser
+from .utils import name_parser_factory
 
 
 class File(object):
@@ -14,8 +14,8 @@ class File(object):
             structs,
             methods,
             has_result):
-        self._package = NameParser(package)
-        self._plugin_name = NameParser(plugin_name)
+        self._package = name_parser_factory.create(package)
+        self._plugin_name = name_parser_factory.create(plugin_name)
         self._template = template_env.get_template("file.j2")
         self._enums = enums
         self._structs = structs

--- a/pb_plugins/dcsdkgen/enum.py
+++ b/pb_plugins/dcsdkgen/enum.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from .name_parser import NameParser
+from .utils import name_parser_factory
 
 
 class Enum(object):
@@ -12,15 +12,15 @@ class Enum(object):
             template_env,
             pb_enum,
             parent_struct=None):
-        self._plugin_name = NameParser(plugin_name)
-        self._package = NameParser(package)
+        self._plugin_name = name_parser_factory.create(plugin_name)
+        self._package = name_parser_factory.create(package)
         self._template = template_env.get_template("enum.j2")
-        self._name = NameParser(pb_enum.name)
+        self._name = name_parser_factory.create(pb_enum.name)
         self._values = []
         self._parent_struct = parent_struct
 
         for value in pb_enum.value:
-            self._values.append(NameParser(value.name))
+            self._values.append(name_parser_factory.create(value.name))
 
     def __repr__(self):
         return self._template.render(plugin_name=self._plugin_name,

--- a/pb_plugins/dcsdkgen/methods.py
+++ b/pb_plugins/dcsdkgen/methods.py
@@ -1,11 +1,11 @@
 # -*- coding: utf-8 -*-
-from .utils import (remove_subscribe,
-                    filter_out_result,
-                    no_return,
+from .utils import (filter_out_result,
                     is_stream,
+                    name_parser_factory,
+                    no_return,
                     Param,
+                    remove_subscribe,
                     type_info_factory)
-from .name_parser import NameParser
 
 
 class Method(object):
@@ -22,9 +22,9 @@ class Method(object):
         self._no_return = False
         self._has_result = False
         self._returns = False
-        self._plugin_name = NameParser(plugin_name)
-        self._package = NameParser(package)
-        self._name = NameParser(pb_method.name)
+        self._plugin_name = name_parser_factory.create(plugin_name)
+        self._package = name_parser_factory.create(package)
+        self._name = name_parser_factory.create(pb_method.name)
         self.extract_params(pb_method, requests)
         self.extract_return_type_and_name(pb_method, responses)
 
@@ -37,7 +37,7 @@ class Method(object):
         for field in request.field:
             self._params.append(
                 Param(
-                    name=NameParser(field.name),
+                    name=name_parser_factory.create(field.name),
                     type_info=type_info_factory.create(field))
             )
 
@@ -57,7 +57,7 @@ class Method(object):
 
         if len(return_params) == 1:
             self._return_type = type_info_factory.create(return_params[0])
-            self._return_name = NameParser(return_params[0].json_name)
+            self._return_name = name_parser_factory.create(return_params[0].json_name)
 
     @property
     def is_stream(self):
@@ -190,7 +190,7 @@ class Stream(Method):
             responses):
         super().__init__(plugin_name, package, pb_method, requests, responses)
         self._is_stream = True
-        self._name = NameParser(remove_subscribe(pb_method.name))
+        self._name = name_parser_factory.create(remove_subscribe(pb_method.name))
         self._template = template_env.get_template("stream.j2")
 
     def __repr__(self):

--- a/pb_plugins/dcsdkgen/struct.py
+++ b/pb_plugins/dcsdkgen/struct.py
@@ -2,10 +2,10 @@
 
 
 from .enum import Enum
-from .name_parser import NameParser
 from .utils import (is_request,
                     is_response,
                     is_struct,
+                    name_parser_factory,
                     Param,
                     type_info_factory)
 from jinja2.exceptions import TemplateNotFound
@@ -15,10 +15,10 @@ class Struct(object):
     """ Struct """
 
     def __init__(self, plugin_name, package, template_env, pb_struct):
-        self._plugin_name = NameParser(plugin_name)
-        self._package = NameParser(package)
+        self._plugin_name = name_parser_factory.create(plugin_name)
+        self._package = name_parser_factory.create(package)
         self._template = template_env.get_template("struct.j2")
-        self._name = NameParser(pb_struct.name)
+        self._name = name_parser_factory.create(pb_struct.name)
         self._fields = []
         self._nested_enums = Enum.collect_enums(
             plugin_name,
@@ -31,7 +31,7 @@ class Struct(object):
 
         for field in pb_struct.field:
             self._fields.append(
-                Param(NameParser(field.json_name),
+                Param(name_parser_factory.create(field.json_name),
                       type_info_factory.create(field)))
 
     def __repr__(self):

--- a/pb_plugins/dcsdkgen/utils.py
+++ b/pb_plugins/dcsdkgen/utils.py
@@ -1,9 +1,11 @@
 # -*- coding: utf-8 -*-
 from jinja2 import Environment, FileSystemLoader
+from .name_parser import NameParserFactory
 from .type_info import TypeInfoFactory
 
 
 type_info_factory = TypeInfoFactory()
+name_parser_factory = NameParserFactory()
 
 
 class Param:

--- a/pb_plugins/test/test_name_parser.py
+++ b/pb_plugins/test/test_name_parser.py
@@ -1,8 +1,11 @@
 import unittest
 
-from dcsdkgen.name_parser import NameParser
+from dcsdkgen.name_parser import (NameParser, NameParserFactory)
+from unittest.mock import patch, mock_open
 
 class TestNameParser(unittest.TestCase):
+
+    _initialisms_data = """ ["HTTP", "HTTPS", "URL", "ID"] """
 
     def setUp(self):
         self.upper_camel_input = "FormattedName"
@@ -23,124 +26,157 @@ class TestNameParser(unittest.TestCase):
         self.single_lower_case = "name"
 
     def test_upper_camel_to_uppercase(self):
-        name = NameParser(self.upper_camel_input)
+        name = NameParser(self.upper_camel_input, [])
         self.assertEqual(self.uppercase, name.uppercase)
 
     def test_lower_camel_to_uppercase(self):
-        name = NameParser(self.lower_camel_input)
+        name = NameParser(self.lower_camel_input, [])
         self.assertEqual(self.uppercase, name.uppercase)
 
     def test_upper_snake_to_uppercase(self):
-        name = NameParser(self.upper_snake_input)
+        name = NameParser(self.upper_snake_input, [])
         self.assertEqual(self.uppercase, name.uppercase)
 
     def test_lower_snake_to_uppercase(self):
-        name = NameParser(self.lower_snake_input)
+        name = NameParser(self.lower_snake_input, [])
         self.assertEqual(self.uppercase, name.uppercase)
 
     def test_only_upper_to_uppercase(self):
-        name = NameParser(self.only_upper_input)
+        name = NameParser(self.only_upper_input, [])
         self.assertEqual(self.single_uppercase, name.uppercase)
 
     def test_only_upper_snake_to_uppercase(self):
-        name = NameParser(self.only_upper_snake_input)
+        name = NameParser(self.only_upper_snake_input, [])
         self.assertEqual(self.uppercase, name.uppercase)
 
     def test_upper_camel_to_upper_camel_case(self):
-        name = NameParser(self.upper_camel_input)
+        name = NameParser(self.upper_camel_input, [])
         self.assertEqual(self.upper_camel_case, name.upper_camel_case)
 
     def test_lower_camel_to_upper_camel_case(self):
-        name = NameParser(self.lower_camel_input)
+        name = NameParser(self.lower_camel_input, [])
         self.assertEqual(self.upper_camel_case, name.upper_camel_case)
 
     def test_upper_snake_to_upper_camel_case(self):
-        name = NameParser(self.upper_snake_input)
+        name = NameParser(self.upper_snake_input, [])
         self.assertEqual(self.upper_camel_case, name.upper_camel_case)
 
     def test_lower_snake_to_upper_camel_case(self):
-        name = NameParser(self.lower_snake_input)
+        name = NameParser(self.lower_snake_input, [])
         self.assertEqual(self.upper_camel_case, name.upper_camel_case)
 
     def test_only_upper_to_upper_camel_case(self):
-        name = NameParser(self.only_upper_input)
+        name = NameParser(self.only_upper_input, [])
         self.assertEqual(self.single_upper_case, name.upper_camel_case)
 
     def test_only_upper_snake_to_upper_camel_case(self):
-        name = NameParser(self.only_upper_snake_input)
+        name = NameParser(self.only_upper_snake_input, [])
         self.assertEqual(self.upper_camel_case, name.upper_camel_case)
 
     def test_upper_camel_to_lower_camel_case(self):
-        name = NameParser(self.upper_camel_input)
+        name = NameParser(self.upper_camel_input, [])
         self.assertEqual(self.lower_camel_case, name.lower_camel_case)
 
     def test_lower_camel_to_lower_camel_case(self):
-        name = NameParser(self.lower_camel_input)
+        name = NameParser(self.lower_camel_input, [])
         self.assertEqual(self.lower_camel_case, name.lower_camel_case)
 
     def test_upper_snake_to_lower_camel_case(self):
-        name = NameParser(self.upper_snake_input)
+        name = NameParser(self.upper_snake_input, [])
         self.assertEqual(self.lower_camel_case, name.lower_camel_case)
 
     def test_lower_snake_to_lower_camel_case(self):
-        name = NameParser(self.lower_snake_input)
+        name = NameParser(self.lower_snake_input, [])
         self.assertEqual(self.lower_camel_case, name.lower_camel_case)
 
     def test_only_upper_to_lower_camel_case(self):
-        name = NameParser(self.only_upper_input)
+        name = NameParser(self.only_upper_input, [])
         self.assertEqual(self.single_lower_case, name.lower_camel_case)
 
     def test_only_upper_snake_to_lower_camel_case(self):
-        name = NameParser(self.only_upper_snake_input)
+        name = NameParser(self.only_upper_snake_input, [])
         self.assertEqual(self.lower_camel_case, name.lower_camel_case)
 
     def test_upper_camel_to_upper_snake_case(self):
-        name = NameParser(self.upper_camel_input)
+        name = NameParser(self.upper_camel_input, [])
         self.assertEqual(self.upper_snake_case, name.upper_snake_case)
 
     def test_lower_camel_to_upper_snake_case(self):
-        name = NameParser(self.lower_camel_input)
+        name = NameParser(self.lower_camel_input, [])
         self.assertEqual(self.upper_snake_case, name.upper_snake_case)
 
     def test_upper_snake_to_upper_snake_case(self):
-        name = NameParser(self.upper_snake_input)
+        name = NameParser(self.upper_snake_input, [])
         self.assertEqual(self.upper_snake_case, name.upper_snake_case)
 
     def test_lower_snake_to_upper_snake_case(self):
-        name = NameParser(self.lower_snake_input)
+        name = NameParser(self.lower_snake_input, [])
         self.assertEqual(self.upper_snake_case, name.upper_snake_case)
 
     def test_only_upper_to_upper_snake_case(self):
-        name = NameParser(self.only_upper_input)
+        name = NameParser(self.only_upper_input, [])
         self.assertEqual(self.single_upper_case, name.upper_snake_case)
 
     def test_only_upper_snake_to_upper_snake_case(self):
-        name = NameParser(self.only_upper_snake_input)
+        name = NameParser(self.only_upper_snake_input, [])
         self.assertEqual(self.upper_snake_case, name.upper_snake_case)
 
     def test_upper_camel_to_lower_snake_case(self):
-        name = NameParser(self.upper_camel_input)
+        name = NameParser(self.upper_camel_input, [])
         self.assertEqual(self.lower_snake_case, name.lower_snake_case)
 
     def test_lower_camel_to_lower_snake_case(self):
-        name = NameParser(self.lower_camel_input)
+        name = NameParser(self.lower_camel_input, [])
         self.assertEqual(self.lower_snake_case, name.lower_snake_case)
 
     def test_upper_snake_to_lower_snake_case(self):
-        name = NameParser(self.upper_snake_input)
+        name = NameParser(self.upper_snake_input, [])
         self.assertEqual(self.lower_snake_case, name.lower_snake_case)
 
     def test_lower_snake_to_lower_snake_case(self):
-        name = NameParser(self.lower_snake_input)
+        name = NameParser(self.lower_snake_input, [])
         self.assertEqual(self.lower_snake_case, name.lower_snake_case)
 
     def test_only_upper_to_lower_snake_case(self):
-        name = NameParser(self.only_upper_input)
+        name = NameParser(self.only_upper_input, [])
         self.assertEqual(self.single_lower_case, name.lower_snake_case)
 
     def test_only_upper_snake_to_lower_snake_case(self):
-        name = NameParser(self.only_upper_snake_input)
+        name = NameParser(self.only_upper_snake_input, [])
         self.assertEqual(self.lower_snake_case, name.lower_snake_case)
+
+    @patch("builtins.open", new_callable=mock_open)
+    def test_no_initialisms_when_no_initialims_file(self, mock_file):
+        mock_file.side_effect = FileNotFoundError()
+        name_parser_factory = NameParserFactory()
+        name = name_parser_factory.create("fileUrl")
+
+        self.assertEqual("FileUrl", name.upper_camel_case)
+        self.assertEqual("fileUrl", name.lower_camel_case)
+        self.assertEqual("file_url", name.lower_snake_case)
+        self.assertEqual("File_Url", name.upper_snake_case)
+
+    @patch("builtins.open", new_callable=mock_open, read_data=_initialisms_data)
+    def test_initalism_is_capitalized_when_camel_case(self, mock_file):
+        name_parser_factory = NameParserFactory()
+        name = name_parser_factory.create("fileUrl")
+
+        self.assertEqual("FileURL", name.upper_camel_case)
+        self.assertEqual("fileURL", name.lower_camel_case)
+
+    @patch("builtins.open", new_callable=mock_open, read_data=_initialisms_data)
+    def test_initalism_is_capitalized_when_upper_snake_case(self, mock_file):
+        name_parser_factory = NameParserFactory()
+        name = name_parser_factory.create("fileUrl")
+
+        self.assertEqual("File_URL", name.upper_snake_case)
+
+    @patch("builtins.open", new_callable=mock_open, read_data=_initialisms_data)
+    def test_initalism_is_not_capitalized_when_lower_snake_case(self, mock_file):
+        name_parser_factory = NameParserFactory()
+        name = name_parser_factory.create("fileUrl")
+
+        self.assertEqual("file_url", name.lower_snake_case)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Some languages find that "Url" is much more difficult to understand than "URL", and that it is worth breaking the cONsiStENCy of CamelCase by keeping initialisms capitalized. And because it is not so easy to have a list of such initialisms, there are only 4 of them in swift-protobuf (nice, isn't it? :sweat_smile:). 

We have to deal with it, because otherwise our generated code doesn't compile with code generated by swift-protobuf. Therefore, I added a list of initialisms in `NameParser`, so that we can break our consistency, too, for those languages.

Notes:
* `NameParser` takes a list of initialisms without a default, because I want to force the use of `NameParserFactory`. 
* The way I treat the initialisms below (with long `map` lines) is not super elegant, but I did not find a better way (I was pissed off, because [look how elegant](https://github.com/Dronecode/DronecodeSDK-Proto/pull/65/files#diff-57beef92659b7dc537130208ff200706R65) it can be without initialisms... :sweat_smile:). Open for suggestions!