### PR TITLE
Fix method type detection

### DIFF
--- a/pb_plugins/dcsdkgen/methods.py
+++ b/pb_plugins/dcsdkgen/methods.py
@@ -58,6 +58,9 @@ class Method(object):
         if len(return_params) == 1:
             self._return_type = type_info_factory.create(return_params[0])
             self._return_name = name_parser_factory.create(return_params[0].json_name)
+        else:
+            self._return_type = None
+            self._return_name = None
 
     @property
     def is_stream(self):
@@ -95,23 +98,23 @@ class Method(object):
         """ Collects all methods for the plugin """
         _methods = {}
         for method in methods:
-            # Check if method is just a call
-            if (no_return(method, responses)):
-                _methods[method.name] = Call(plugin_name,
-                                             package,
-                                             template_env,
-                                             method,
-                                             requests,
-                                             responses)
-
             # Check if stream
-            elif (is_stream(method)):
+            if (is_stream(method)):
                 _methods[method.name] = Stream(plugin_name,
                                                package,
                                                template_env,
                                                method,
                                                requests,
                                                responses)
+
+            # Check if method is just a call
+            elif (no_return(method, responses)):
+                _methods[method.name] = Call(plugin_name,
+                                             package,
+                                             template_env,
+                                             method,
+                                             requests,
+                                             responses)
 
             else:
                 _methods[method.name] = Request(plugin_name,


### PR DESCRIPTION
Previously, we were first checking if a method was a `Call` by checking if it has no return value. However, we could have a stream of `void` elements. This PR makes it such that we first check if a method is a `stream`.

Also, because a stream can have no return value, we need to set it to `None`, so that the template can deal with it.

I wonder if it makes sense to support streams of `void`, but we have one already, so it has to be supported. Maybe later, `discover` and `timeout` (in Core) should be merged, and then we could decide to not support streams of `void`...