### PR TITLE
core: merge 'discover' and 'timeout' into a single 'connection_state'

### DIFF
--- a/protos/core/core.proto
+++ b/protos/core/core.proto
@@ -6,22 +6,23 @@ option java_package = "io.dronecode_sdk.core";
 option java_outer_classname = "CoreProto";
 
 service CoreService {
-    rpc SubscribeDiscover(SubscribeDiscoverRequest) returns(stream DiscoverResponse) {}
-    rpc SubscribeTimeout(SubscribeTimeoutRequest) returns(stream TimeoutResponse) {}
+    rpc SubscribeConnectionState(SubscribeConnectionStateRequest) returns(stream ConnectionStateResponse) {}
     rpc ListRunningPlugins(ListRunningPluginsRequest) returns(ListRunningPluginsResponse) {}
 }
 
-message SubscribeDiscoverRequest {}
-message DiscoverResponse {
-    uint64 uuid = 1;
+message SubscribeConnectionStateRequest {}
+message ConnectionStateResponse {
+    ConnectionState connection_state = 1;
 }
-
-message SubscribeTimeoutRequest {}
-message TimeoutResponse {}
 
 message ListRunningPluginsRequest {}
 message ListRunningPluginsResponse {
     repeated PluginInfo plugin_info = 1;
+}
+
+message ConnectionState {
+    uint64 uuid = 1;
+    bool is_connected = 2;
 }
 
 message PluginInfo {


### PR DESCRIPTION
That was an old suggestion from @byuarus, which I believe makes sense. In practice, we mostly use both calls together.

Note that in the middle term this will change the C++ API as well (when it is auto-generated). But I believe it makes sense there as well.