### PR TITLE
Add template_path as a parameter to protoc plugin

### DIFF
--- a/pb_plugins/dcsdkgen/name_parser.py
+++ b/pb_plugins/dcsdkgen/name_parser.py
@@ -4,22 +4,21 @@ import re
 from os import environ
 
 class NameParserFactory:
-
-    def __init__(self):
-        self._initialisms = self._load_initialisms()
+    _initialisms = []
 
     def create(self, name):
         return NameParser(name, self._initialisms)
 
-    def _load_initialisms(self):
+    def set_template_path(self, template_path):
+        self._initialisms = self._load_initialisms(template_path)
+
+    def _load_initialisms(self, template_path):
         try:
-            _template_path = environ.get("TEMPLATE_PATH", "./")
-            _initialisms_path = f"{_template_path}/initialisms"
+            _initialisms_path = f"{template_path}/initialisms"
             with open(_initialisms_path, "r") as handle:
                 return json.loads(handle.read())
         except FileNotFoundError:
             return []
-
 
 
 class NameParser:

--- a/pb_plugins/dcsdkgen/type_info.py
+++ b/pb_plugins/dcsdkgen/type_info.py
@@ -3,17 +3,17 @@ from os import environ
 
 
 class TypeInfoFactory:
-
-    def __init__(self):
-        self._conversion_dict = self._load_conversions_dict()
+    _conversion_dict = {}
 
     def create(self, field):
         return TypeInfo(field, self._conversion_dict)
 
-    def _load_conversions_dict(self):
+    def set_template_path(self, template_path):
+        self._conversion_dict = self._load_conversions_dict(template_path)
+
+    def _load_conversions_dict(self, template_path):
         try:
-            _template_path = environ.get("TEMPLATE_PATH", "./")
-            _conversion_dict_path = f"{_template_path}/type_conversions"
+            _conversion_dict_path = f"{template_path}/type_conversions"
             with open(_conversion_dict_path, "r") as handle:
                 return json.loads(handle.read())
         except FileNotFoundError:

--- a/pb_plugins/dcsdkgen/utils.py
+++ b/pb_plugins/dcsdkgen/utils.py
@@ -4,8 +4,8 @@ from .name_parser import NameParserFactory
 from .type_info import TypeInfoFactory
 
 
-type_info_factory = TypeInfoFactory()
 name_parser_factory = NameParserFactory()
+type_info_factory = TypeInfoFactory()
 
 
 class Param:

--- a/pb_plugins/test/test_name_parser.py
+++ b/pb_plugins/test/test_name_parser.py
@@ -159,6 +159,7 @@ class TestNameParser(unittest.TestCase):
     @patch("builtins.open", new_callable=mock_open, read_data=_initialisms_data)
     def test_initalism_is_capitalized_when_camel_case(self, mock_file):
         name_parser_factory = NameParserFactory()
+        name_parser_factory.set_template_path("random/path")
         name = name_parser_factory.create("fileUrl")
 
         self.assertEqual("FileURL", name.upper_camel_case)
@@ -167,6 +168,7 @@ class TestNameParser(unittest.TestCase):
     @patch("builtins.open", new_callable=mock_open, read_data=_initialisms_data)
     def test_initalism_is_capitalized_when_upper_snake_case(self, mock_file):
         name_parser_factory = NameParserFactory()
+        name_parser_factory.set_template_path("random/path")
         name = name_parser_factory.create("fileUrl")
 
         self.assertEqual("File_URL", name.upper_snake_case)
@@ -174,6 +176,7 @@ class TestNameParser(unittest.TestCase):
     @patch("builtins.open", new_callable=mock_open, read_data=_initialisms_data)
     def test_initalism_is_not_capitalized_when_lower_snake_case(self, mock_file):
         name_parser_factory = NameParserFactory()
+        name_parser_factory.set_template_path("random/path")
         name = name_parser_factory.create("fileUrl")
 
         self.assertEqual("file_url", name.lower_snake_case)

--- a/pb_plugins/test/test_type_info.py
+++ b/pb_plugins/test/test_type_info.py
@@ -42,6 +42,7 @@ class TestTypeInfo(unittest.TestCase):
     @patch("builtins.open", new_callable=mock_open, read_data=_conversion_dict_data)
     def test_name_uses_default_when_no_conversion(self, mock_file):
         type_info_factory = TypeInfoFactory()
+        type_info_factory.set_template_path("random/path")
         type_info = type_info_factory.create(self.primitive_field(self.double_id, self.non_repeated_label))
 
         self.assertEqual(type_info.name, self.double_expected_default_str)
@@ -49,6 +50,7 @@ class TestTypeInfo(unittest.TestCase):
     @patch("builtins.open", new_callable=mock_open, read_data=_conversion_dict_data)
     def test_name_converts_type_when_conversion(self, mock_file):
         type_info_factory = TypeInfoFactory()
+        type_info_factory.set_template_path("random/path")
         type_info = type_info_factory.create(self.primitive_field(self.bool_id, self.non_repeated_label))
 
         self.assertEqual(type_info.name, self.bool_expected_converted_str)
@@ -56,6 +58,7 @@ class TestTypeInfo(unittest.TestCase):
     @patch("builtins.open", new_callable=mock_open, read_data=_conversion_dict_data)
     def test_name_raises_error_when_invalid_type(self, mock_file):
         type_info_factory = TypeInfoFactory()
+        type_info_factory.set_template_path("random/path")
         type_info = type_info_factory.create(self.primitive_field(self.invalid_id, self.non_repeated_label))
 
         with self.assertRaises(ValueError):
@@ -64,6 +67,7 @@ class TestTypeInfo(unittest.TestCase):
     @patch("builtins.open", new_callable=mock_open, read_data=_conversion_dict_data)
     def test_primitive_false_for_complex_types(self, mock_file):
         type_info_factory = TypeInfoFactory()
+        type_info_factory.set_template_path("random/path")
 
         for type_id in {11, 14}:
             non_primitive_type = type_info_factory.create(self.primitive_field(type_id, self.non_repeated_label))
@@ -72,6 +76,7 @@ class TestTypeInfo(unittest.TestCase):
     @patch("builtins.open", new_callable=mock_open, read_data=_conversion_dict_data)
     def test_primitive_true_for_primitive_types(self, mock_file):
         type_info_factory = TypeInfoFactory()
+        type_info_factory.set_template_path("random/path")
 
         for type_id in {1, 2, 3, 4, 5, 8, 9, 12, 13}:
             primitive_type = type_info_factory.create(self.primitive_field(type_id, self.non_repeated_label))
@@ -80,6 +85,7 @@ class TestTypeInfo(unittest.TestCase):
     @patch("builtins.open", new_callable=mock_open, read_data=_conversion_dict_data)
     def test_is_result_false_for_primitive_types(self, mock_file):
         type_info_factory = TypeInfoFactory()
+        type_info_factory.set_template_path("random/path")
 
         for type_id in {1, 2, 3, 4, 5, 8, 9, 12, 13}:
             primitive_type = type_info_factory.create(self.primitive_field(type_id, self.non_repeated_label))
@@ -88,6 +94,7 @@ class TestTypeInfo(unittest.TestCase):
     @patch("builtins.open", new_callable=mock_open, read_data=_conversion_dict_data)
     def test_is_result_false_for_complex_non_result_types(self, mock_file):
         type_info_factory = TypeInfoFactory()
+        type_info_factory.set_template_path("random/path")
 
         for type_id in {11, 14}:
             complex_type = type_info_factory.create(self.non_primitive_field(type_id, "SomeNonResultType", self.non_repeated_label))
@@ -96,6 +103,7 @@ class TestTypeInfo(unittest.TestCase):
     @patch("builtins.open", new_callable=mock_open, read_data=_conversion_dict_data)
     def test_is_result_true_for_result_types(self, mock_file):
         type_info_factory = TypeInfoFactory()
+        type_info_factory.set_template_path("random/path")
 
         for type_id in {11, 14}:
             complex_type = type_info_factory.create(self.non_primitive_field(type_id, "SomeResult", self.non_repeated_label))
@@ -104,6 +112,7 @@ class TestTypeInfo(unittest.TestCase):
     @patch("builtins.open", new_callable=mock_open, read_data=_conversion_dict_data_repeatable)
     def test_repeated_false_for_non_repeated_primitive(self, mock_file):
         type_info_factory = TypeInfoFactory()
+        type_info_factory.set_template_path("random/path")
         non_repeated_primitive_type = type_info_factory.create(self.primitive_field(self.double_id, self.non_repeated_label))
 
         self.assertFalse(non_repeated_primitive_type.is_repeated)
@@ -111,6 +120,7 @@ class TestTypeInfo(unittest.TestCase):
     @patch("builtins.open", new_callable=mock_open, read_data=_conversion_dict_data_repeatable)
     def test_repeated_true_for_repeated_primitive(self, mock_file):
         type_info_factory = TypeInfoFactory()
+        type_info_factory.set_template_path("random/path")
         repeated_primitive_type = type_info_factory.create(self.primitive_field(self.double_id, self.repeated_label))
 
         self.assertTrue(repeated_primitive_type.is_repeated)
@@ -118,6 +128,7 @@ class TestTypeInfo(unittest.TestCase):
     @patch("builtins.open", new_callable=mock_open, read_data=_conversion_dict_data_repeatable)
     def test_repeated_false_for_non_repeated(self, mock_file):
         type_info_factory = TypeInfoFactory()
+        type_info_factory.set_template_path("random/path")
         non_repeated_type = type_info_factory.create(self.non_primitive_field(11, "SomeNonResultType", self.non_repeated_label))
 
         self.assertFalse(non_repeated_type.is_repeated)
@@ -125,6 +136,7 @@ class TestTypeInfo(unittest.TestCase):
     @patch("builtins.open", new_callable=mock_open, read_data=_conversion_dict_data_repeatable)
     def test_repeated_true_for_repeated(self, mock_file):
         type_info_factory = TypeInfoFactory()
+        type_info_factory.set_template_path("random/path")
         repeated_type = type_info_factory.create(self.non_primitive_field(11, "SomeNonResultType", self.repeated_label))
 
         self.assertTrue(repeated_type.is_repeated)
@@ -132,6 +144,7 @@ class TestTypeInfo(unittest.TestCase):
     @patch("builtins.open", new_callable=mock_open, read_data=_conversion_dict_data_repeatable)
     def test_name_adds_prefix_suffix_for_repeated_primitive(self, mock_file):
         type_info_factory = TypeInfoFactory()
+        type_info_factory.set_template_path("random/path")
         type_info = type_info_factory.create(self.primitive_field(self.double_id, self.repeated_label))
 
         self.assertEqual(type_info.name, "prefix[double]suffix")
@@ -139,6 +152,7 @@ class TestTypeInfo(unittest.TestCase):
     @patch("builtins.open", new_callable=mock_open, read_data=_conversion_dict_data)
     def test_name_adds_default_prefix_suffix_when_repeated_primitive_not_in_conversion_dict(self, mock_file):
         type_info_factory = TypeInfoFactory()
+        type_info_factory.set_template_path("random/path")
         type_info = type_info_factory.create(self.primitive_field(self.double_id, self.repeated_label))
 
         self.assertEqual(type_info.name, "std::vector<double>")
@@ -146,6 +160,7 @@ class TestTypeInfo(unittest.TestCase):
     @patch("builtins.open", new_callable=mock_open, read_data=_conversion_dict_data_repeatable)
     def test_name_adds_prefix_suffix_for_repeated(self, mock_file):
         type_info_factory = TypeInfoFactory()
+        type_info_factory.set_template_path("random/path")
         type_info = type_info_factory.create(self.non_primitive_field(11, "SomeNonResultType", self.repeated_label))
 
         self.assertEqual(type_info.name, "prefix[SomeNonResultType]suffix")
@@ -153,6 +168,7 @@ class TestTypeInfo(unittest.TestCase):
     @patch("builtins.open", new_callable=mock_open, read_data=_conversion_dict_data)
     def test_name_adds_default_prefix_suffix_when_repeated_not_in_conversion_dict(self, mock_file):
         type_info_factory = TypeInfoFactory()
+        type_info_factory.set_template_path("random/path")
         type_info = type_info_factory.create(self.non_primitive_field(11, "SomeNonResultType", self.repeated_label))
 
         self.assertEqual(type_info.name, "std::vector<SomeNonResultType>")
@@ -160,6 +176,7 @@ class TestTypeInfo(unittest.TestCase):
     @patch("builtins.open", new_callable=mock_open, read_data=_conversion_dict_data_repeatable)
     def test_inner_name_for_repeated(self, mock_file):
         type_info_factory = TypeInfoFactory()
+        type_info_factory.set_template_path("random/path")
         type_info = type_info_factory.create(self.non_primitive_field(11, "SomeNonResultType", self.repeated_label))
 
         self.assertEqual(type_info.inner_name, "SomeNonResultType")


### PR DESCRIPTION
Our protoc plugin now takes `template_path` from the protoc options. The goal is to not have to use the `TEMPLATE_PATH` environment variable. I find it cleaner, and used it in the gradle integration.

The `TEMPLATE_PATH` environment variable can still be used, but should
probably be deprecated some time soon. Or do you guys like having both possibilities? I would vote for aiming at having one way to do a thing :-). 