### PR TITLE
dcsdkgen: add parent_type to type info

### DIFF
--- a/pb_plugins/dcsdkgen/type_info.py
+++ b/pb_plugins/dcsdkgen/type_info.py
@@ -72,6 +72,24 @@ class TypeInfo:
             return self._default_types[type_id]
 
     @property
+    def parent_type(self):
+        """ Extracts parent type. This assumes that nesting is not deeper
+        than 1 level.
+
+        Note that it also assumes that the package name has 3 words. It
+        will start with a '.', giving something like:
+        '.org.dronecode.sdk.ActionResult.Result'."""
+        if self.is_primitive:
+            return None
+
+        type_tree = self._field.type_name.split(".")
+
+        if len(type_tree) <= 5:
+            return None
+
+        return str(type_tree[-2])
+
+    @property
     def is_result(self):
         """ Check if the field is a *Result """
         return self.name.endswith("Result")


### PR DESCRIPTION
In some languages (like Python), nested enums need to know their parent name. This adds it to type_info.

This is assuming only one level of nesting. It could probably be generalized, but we don't have such an example yet.

It also assumes (for now) that the package name has 3 levels (e.g. "org.dronecode.sdk"), but I believe I could solve that with the generalized nesting handling.

Required to fix [this issue](https://github.com/Dronecode/DronecodeSDK-Python/issues/47).