### PR TITLE
Various fixes

### DIFF
--- a/pb_plugins/dcsdkgen/autogen.py
+++ b/pb_plugins/dcsdkgen/autogen.py
@@ -22,6 +22,8 @@ class AutoGen(object):
         type_info_factory.set_template_path(params["template_path"])
         template_env = get_template_env(params["template_path"])
 
+        _codegen_response = plugin_pb2.CodeGeneratorResponse()
+
         for proto_file in request.proto_file:
             plugin_name = proto_file.name.split('.')[0].capitalize()
 
@@ -57,14 +59,12 @@ class AutoGen(object):
                             methods,
                             has_result(structs))
 
-            _codegen_response = plugin_pb2.CodeGeneratorResponse()
-
             # Fill response
             f = _codegen_response.file.add()
             f.name = f"{plugin_name}.{params['file_ext']}"
             f.content = str(out_file)
 
-            return _codegen_response
+        return _codegen_response
 
     @staticmethod
     def parse_parameter(parameter):

--- a/pb_plugins/dcsdkgen/autogen.py
+++ b/pb_plugins/dcsdkgen/autogen.py
@@ -73,7 +73,8 @@ class AutoGen(object):
         params_dict = {}
         for raw_param in raw_params:
             split_param = raw_param.split('=')
-            params_dict[split_param[0]] = split_param[1]
+            if len(split_param) == 2:
+                params_dict[split_param[0]] = split_param[1]
 
         if 'file_ext' not in params_dict:
             raise Exception("'file_ext' option was not specified! See " +


### PR DESCRIPTION
* Fix build for multiple proto files (previously it was returning after the first file)
* Improve error handling when protoc is run with the `file_ext` option missing
* Output java files in the right directory, according to java conventions (i.e. use the package)