### PR TITLE
Add mavlink messages support.

### DIFF
--- a/protos/telemetry/telemetry.proto
+++ b/protos/telemetry/telemetry.proto
@@ -20,6 +20,7 @@ service TelemetryService {
     rpc SubscribeFlightMode(SubscribeFlightModeRequest) returns(stream FlightModeResponse) {}
     rpc SubscribeHealth(SubscribeHealthRequest) returns(stream HealthResponse) {}
     rpc SubscribeRcStatus(SubscribeRcStatusRequest) returns(stream RcStatusResponse) {}
+    rpc SubscribeMavMessage(SubscribeMavMessageRequest) returns(stream MavMessageResponse) {}
 }
 
 message SubscribePositionRequest {}
@@ -90,6 +91,11 @@ message HealthResponse {
 message SubscribeRcStatusRequest {}
 message RcStatusResponse {
     RcStatus rc_status = 1;
+}
+
+message SubscribeMavMessageRequest {}
+message MavMessageResponse {
+    MavMessage mav_message = 1;
 }
 
 message Position {
@@ -164,4 +170,21 @@ message RcStatus {
     bool was_available_once = 1;
     bool is_available = 2;
     float signal_strength_percent = 3;
+}
+
+message MavMessage {
+    enum Type {
+        EMERGENCY = 0;
+        ALERT = 1;
+        CRITICAL = 2;
+        ERROR = 3;
+        WARNING = 4;
+        NOTICE = 5;
+        INFO = 6;
+        DEBUS = 7;
+        UNKNOWN = 8;
+    }
+    
+    MessageType type = 1;
+    string text = 2;
 }

--- a/protos/telemetry/telemetry.proto
+++ b/protos/telemetry/telemetry.proto
@@ -174,9 +174,9 @@ message RcStatus {
 
 message StatusText {
     enum Type {
-        INFO = 1;
-        WARNING = 2;
-        CRITICAL = 3;
+        INFO = 0;
+        WARNING = 1;
+        CRITICAL = 2;
     }
     
     Type type = 1;

--- a/protos/telemetry/telemetry.proto
+++ b/protos/telemetry/telemetry.proto
@@ -175,7 +175,7 @@ message RcStatus {
 message StatusText {
     enum Type {
         INFO = 1;
-        WARNING = 2
+        WARNING = 2;
         CRITICAL = 3;
     }
     

--- a/protos/telemetry/telemetry.proto
+++ b/protos/telemetry/telemetry.proto
@@ -20,7 +20,7 @@ service TelemetryService {
     rpc SubscribeFlightMode(SubscribeFlightModeRequest) returns(stream FlightModeResponse) {}
     rpc SubscribeHealth(SubscribeHealthRequest) returns(stream HealthResponse) {}
     rpc SubscribeRcStatus(SubscribeRcStatusRequest) returns(stream RcStatusResponse) {}
-    rpc SubscribeMavMessage(SubscribeMavMessageRequest) returns(stream MavMessageResponse) {}
+    rpc SubscribeStatusText(SubscribeStatusTextRequest) returns(stream StatusTextResponse) {}
 }
 
 message SubscribePositionRequest {}
@@ -93,9 +93,9 @@ message RcStatusResponse {
     RcStatus rc_status = 1;
 }
 
-message SubscribeMavMessageRequest {}
-message MavMessageResponse {
-    MavMessage mav_message = 1;
+message SubscribeStatusTextRequest {}
+message StatusTextResponse {
+    StatusText status_text = 1;
 }
 
 message Position {
@@ -172,19 +172,13 @@ message RcStatus {
     float signal_strength_percent = 3;
 }
 
-message MavMessage {
+message StatusText {
     enum Type {
-        EMERGENCY = 0;
-        ALERT = 1;
-        CRITICAL = 2;
-        ERROR = 3;
-        WARNING = 4;
-        NOTICE = 5;
-        INFO = 6;
-        DEBUS = 7;
-        UNKNOWN = 8;
+        INFO = 1;
+        WARNING = 2
+        CRITICAL = 3;
     }
     
-    MessageType type = 1;
+    Type type = 1;
     string text = 2;
 }

--- a/protos/telemetry/telemetry.proto
+++ b/protos/telemetry/telemetry.proto
@@ -173,12 +173,12 @@ message RcStatus {
 }
 
 message StatusText {
-    enum Type {
+    enum StatusType {
         INFO = 0;
         WARNING = 1;
         CRITICAL = 2;
     }
     
-    Type type = 1;
+    StatusType type = 1;
     string text = 2;
 }


### PR DESCRIPTION
Hey guys, I'm implementing the reading mavlink messages from the SDK and was wondering if this is the best way to do it. Please let me know what you think. 

Note that I tried to use `DEBUG` in the enum, but the compiler complained, so I'm using `DEBUS = 7;` for now, let me know what would be a good alternative word. 
